### PR TITLE
Multiline JSON when saving data

### DIFF
--- a/js/filemanager.js
+++ b/js/filemanager.js
@@ -131,7 +131,7 @@ function saveDataChrome() {
 
   if (chosenFileEntry) {
     myname = chosenFileEntry.name;
-    var blob = new Blob([JSON.stringify(WaveMaker)], {
+    var blob = new Blob([JSON.stringify(WaveMaker, null, 2)], {
       type: "text/json"
     });
     writeFileEntry(chosenFileEntry, blob, function (e) {
@@ -154,7 +154,7 @@ function saveDataChrome() {
         $("#saveAlert").fadeOut();
         autosaveTrigger = true;
       } else {
-        var blob = new Blob([JSON.stringify(WaveMaker)], {
+        var blob = new Blob([JSON.stringify(WaveMaker, null, 2)], {
           type: "text/json"
         });
         chosenFileEntry = writableEntry;
@@ -348,7 +348,7 @@ function electronLoad() {
 function saveDataElectron() {
   $("#saveAlert").show();
   console.log("save Triggered");
-  let content = JSON.stringify(WaveMaker);
+  let content = JSON.stringify(WaveMaker, null, 2);
   const { dialog } = require("electron").remote;
   fs = require("fs");
   // You can obviously give a direct path without use the dialog (C:/Program Files/path/myfileexample.txt)


### PR DESCRIPTION
I made this change in the GitHub editor, so I'm not 100% sure this is the correct place.

Normally the saved data is all on a single line like so:
```json
    {"settings":{"theme":"dark"},"timeline":[],"writer":{...
```

After this change it will be spread over multiple lines:
```json
    {
      "settings": {
        "theme": "dark"
      },
      "timeline": [],
      "writer": {...
```

This is done so that the exported data file is more friendly with git.

As an example, if the complete data file is on a single line, it would be impossible for two users to ever merge changes together.

As another example, if the data file is 1MB large and a single line, every commit would increase the repo size by 1MB. However, spread over many lines, each commit increases the repo size by maybe a few KB.